### PR TITLE
Broken classpath entry

### DIFF
--- a/src/org/scalastuff/esbt/SbtEclipsePlugin.scala.source
+++ b/src/org/scalastuff/esbt/SbtEclipsePlugin.scala.source
@@ -24,9 +24,9 @@ object SbtEclipsePlugin extends Plugin
     (baseDirectory, update) map {
       (base, report) => 
         val tuples = for (configuration <- report.configurations; module <- configuration.modules) yield {
-          module.artifacts.find(_._1.classifier == None) match {
+          module.artifacts.find(_._1.`type` == "jar") match {
           case Some(art) =>
-            val source = module.artifacts.find(_._1.classifier == Some("sources")) match {
+            val source = module.artifacts.find(_._1.`type` == "src") match {
               case Some(art) => " :: " + relativize(base, art._2)
               case None => ""
           }


### PR DESCRIPTION
esbt is creating a broken eclipse classpath entry pointing to a pom file instead of pointing to the corresponding jar.

Here's my build.sbt:

```
organization := "plalloni"

name := "sutil"

version := "0.1"

scalaVersion := "2.9.1"

libraryDependencies ++= Seq(
      "org.clapper" %% "grizzled-slf4j" % "0.6.5",
      "org.scalaz" %% "scalaz-core" % "6.0.3",
      "org.scalaquery" %% "scalaquery" % "0.9.5-plalloni1",
      "ch.qos.logback" % "logback-classic" % "0.9.29" % "test")
```

esbt creates the following ".classpath" file:

```
<classpath>
    <classpathentry kind="output" path="target/classes"/>
    <classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
    <classpathentry from="sbt" kind="lib" path="/home/plalloni/.esbt/jars/org.clapper-grizzled-slf4j_2.9.1-0.6.5.jar"/>
    <classpathentry from="sbt" kind="lib" path="/home/plalloni/.esbt/jars/ch.qos.logback-logback-classic-0.9.29.jar"/>
    <classpathentry from="sbt" kind="lib" path="/home/plalloni/.esbt/jars/ch.qos.logback-logback-core-0.9.29.jar"/>
    <classpathentry from="sbt" kind="lib" path="/home/plalloni/.esbt/jars/org.scalaquery-scalaquery_2.9.1.pom" sourcepath="/home/plalloni/.esbt/jars/org.scalaquery-scalaquery_2.9.1-sources.jar"/>
    <classpathentry from="sbt" kind="lib" path="/home/plalloni/.esbt/jars/org.scalaz-scalaz-core_2.9.1-6.0.3.jar"/>
    <classpathentry from="sbt" kind="lib" path="/home/plalloni/.esbt/jars/org.slf4j-slf4j-api-1.6.2.jar"/>
    <classpathentry from="sbt" kind="src" path="src/main/scala/"/>
    <classpathentry from="sbt" kind="src" path="src/main/resources/"/>
    <classpathentry from="sbt" kind="src" path="src/test/scala/"/>
    <classpathentry from="sbt" kind="src" path="src/test/resources/"/>
</classpath>
```

Where the entry pointing to the pom "/home/plalloni/.esbt/jars/org.scalaquery-scalaquery_2.9.1.pom" should be pointing to the jar file instead.

On plain sbt from the command line sbt-0.10.1 compiles and packages the project just fine.

I don't know if this is relevant, but the wrongly added dependency is an sbt-0.7 locally installed (~/.ivy2) project which you can have with a plain clone of git://github.com/plalloni/scala-query.git and doing "sbt publish-local" with sbt-0.7.7.

The proposed change modifies SbtEclipsePlugin.scala.source to use artifacts' types instead of classifier to pick jar and sources files.
